### PR TITLE
feat(#2, #10):Feature/pokemon list components

### DIFF
--- a/src/components/organisms/List/Species/effects.ts
+++ b/src/components/organisms/List/Species/effects.ts
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+
+import { Params } from "./type";
+
+const usePokemonSpeciesEffects = (params: Params) => {
+  const { handlePokemonList, setSpeciesList } = params;
+
+  //TODO: useCallback
+  const usePokemonListEffect = () => {
+    useEffect(() => {
+      handlePokemonList();
+    }, [setSpeciesList]); // TODO: 디펜더시 추가
+  };
+
+  return { usePokemonListEffect } as const;
+};
+
+export default usePokemonSpeciesEffects;

--- a/src/components/organisms/List/Species/handlers.ts
+++ b/src/components/organisms/List/Species/handlers.ts
@@ -1,0 +1,37 @@
+import { States } from "./type";
+
+const usePokemonSpeciesHandlers = (states: States) => {
+  const { getPokemonList, setSpeciesList } = states;
+
+  const handlePokemonList = async () => {
+    const KOR_LANGUAGE_ID = 3;
+    const { data } = await getPokemonList({
+      variables: { limit: 50, offset: 0, orderBy: { pokemon_id: "asc" } }, //TODO: query param으로 변경
+    });
+
+    const pokemonDataList = data?.pokemon_v2_pokemonsprites.map((sprite) => {
+      //TODO: 이미지가 null일 경우는 어떻게..?
+      const image = JSON.parse(sprite.sprites)["front_default"]
+        ? JSON.parse(sprite.sprites)["front_default"]
+        : JSON.parse(sprite.sprites)["other"]["official-artwork"][
+            "front_default"
+          ];
+
+      const info =
+        sprite.pokemon_v2_pokemon?.pokemon_v2_pokemonspecy?.pokemon_v2_pokemonspeciesnames_aggregate.nodes.filter(
+          (node) => node.language_id === KOR_LANGUAGE_ID
+        )[0];
+
+      return {
+        ...info,
+        image: image.replace("/media", ""),
+      };
+    });
+
+    setSpeciesList(pokemonDataList); //TODO: 최종 버전때 타입 다시 수정하기
+  };
+
+  return { handlePokemonList } as const;
+};
+
+export default usePokemonSpeciesHandlers;

--- a/src/components/organisms/List/Species/index.tsx
+++ b/src/components/organisms/List/Species/index.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+
+import usePokemonSpeciesStates from "./states";
+import usePokemonSpeciesHandlers from "./handlers";
+import usePokemonSpeciesEffects from "./effects";
+import { SpeciesContainer, SpeciesWrapper } from "./styles";
+
+const PokemonSpecies = () => {
+  const states = usePokemonSpeciesStates();
+  const handlers = usePokemonSpeciesHandlers(states);
+  const { usePokemonListEffect } = usePokemonSpeciesEffects({
+    ...states,
+    ...handlers,
+  });
+  const { speciesList } = states;
+
+  usePokemonListEffect();
+
+  return (
+    <>
+      {speciesList?.length > 0 &&
+        speciesList.map((value: any, i: number) => {
+          return (
+            <SpeciesWrapper key={i}>
+              <SpeciesContainer>
+                <img
+                  src={`https://raw.githubusercontent.com/PokeAPI/sprites/master/${value.image}`}
+                />
+                <div>{value.name}</div>
+              </SpeciesContainer>
+            </SpeciesWrapper>
+          );
+        })}
+    </>
+  );
+};
+
+export default PokemonSpecies;

--- a/src/components/organisms/List/Species/states.ts
+++ b/src/components/organisms/List/Species/states.ts
@@ -1,0 +1,15 @@
+import { usePokemonListLazyQuery } from "@/gql/poke/pokemonList.graphql";
+import { useStore } from "@/store";
+
+const usePokemonSpeciesStates = () => {
+  const [getPokemonList] = usePokemonListLazyQuery();
+  const { pokemonStore } = useStore();
+  const { setSpeciesList, speciesList } = pokemonStore;
+
+  const setter = { setSpeciesList };
+  const getter = { getPokemonList, speciesList };
+
+  return { ...setter, ...getter };
+};
+
+export default usePokemonSpeciesStates;

--- a/src/components/organisms/List/Species/styles.ts
+++ b/src/components/organisms/List/Species/styles.ts
@@ -1,0 +1,12 @@
+import { styled } from "@/styles/stitches.config";
+
+export const SpeciesWrapper = styled("div", {
+  display: "flex",
+  border: "1px solid black",
+  flexWrap: "wrap",
+});
+export const SpeciesContainer = styled("div", {
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+});

--- a/src/components/organisms/List/Species/type.ts
+++ b/src/components/organisms/List/Species/type.ts
@@ -1,0 +1,6 @@
+import usePokemonSpeciesHandlers from "./handlers";
+import usePokemonSpeciesStates from "./states";
+
+export type States = ReturnType<typeof usePokemonSpeciesStates>;
+export type Params = ReturnType<typeof usePokemonSpeciesStates> &
+  ReturnType<typeof usePokemonSpeciesHandlers>;

--- a/src/components/templates/List/index.tsx
+++ b/src/components/templates/List/index.tsx
@@ -1,0 +1,7 @@
+import PokemonSpecies from "@/components/organisms/List/Species";
+
+const PokemonList = () => {
+  return <PokemonSpecies />;
+};
+
+export default PokemonList;

--- a/src/gql/poke/pokemonList.gql
+++ b/src/gql/poke/pokemonList.gql
@@ -1,11 +1,26 @@
-query pokemonList($limit: Int, $offset: Int) {
-  pokemon_v2_pokemon(limit: $limit, offset: $offset) {
-    pokemon_v2_pokemonspecy {
-      pokemon_v2_pokemonspeciesnames_aggregate {
-        nodes {
-          name
-          language_id
-          genus
+query pokemonList(
+  $limit: Int
+  $offset: Int
+  $orderBy: [pokemon_v2_pokemonsprites_order_by!]
+) {
+  pokemon_v2_pokemonsprites(
+    limit: $limit
+    offset: $offset
+    order_by: $orderBy
+  ) {
+    sprites
+    id
+    pokemon_id
+    pokemon_v2_pokemon {
+      name
+      pokemon_v2_pokemonspecy {
+        pokemon_v2_pokemonspeciesnames_aggregate {
+          nodes {
+            name
+            language_id
+            id
+            genus
+          }
         }
       }
     }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,14 +1,5 @@
-import { Inter } from "next/font/google";
-
-import { usePokemon_V2_VersionnameQuery } from "@/gql/poke/exam.graphql";
-
-const inter = Inter({ subsets: ["latin"] });
+import PokemonList from "@/components/templates/List";
 
 export default function Home() {
-  const { data, loading } = usePokemon_V2_VersionnameQuery({
-    variables: { pokemonV2LocationnameByPkId: 1 },
-  });
-
-  if (loading) return <div>loading...</div>;
-  return <div>{data?.pokemon_v2_locationname_by_pk?.name}</div>;
+  return <PokemonList />;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,1 @@
+export type InferArray<T extends unknown[]> = T extends (infer U)[] ? U : never;


### PR DESCRIPTION
### 관련 문서
<!--노션, Figma, 이슈 등의 링크-->

Closes [#2 ]

[포켓몬 페이지 목록을 구현한다.](https://github.com/rainleee/poke/issues/10 )

### 변경사항:
<!--중요 커밋은 링크로 연결해서 추가-->

### 확인할 목록:
<!--테스트 목록 및 테스트 방법을 작성-->